### PR TITLE
py23: add __future__ imports; use py2-and-3 version of super()

### DIFF
--- a/Lib/defconQt/controls/accordionBox.py
+++ b/Lib/defconQt/controls/accordionBox.py
@@ -8,6 +8,7 @@ to reveal or hide its contents, in the form of :class:`AccordionBox`.
 :class:`AccordionGroup` is a set of AccordionBox that can be used to ensure
 only one is open at a time.
 """
+from __future__ import absolute_import
 from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import (
     QGroupBox, QProxyStyle, QStyle, QStyleOption, QWidget)
@@ -28,9 +29,9 @@ class AccordionProxy(QProxyStyle):
             option_.state |= QStyle.State_Children
             if widget.isChecked():
                 option_.state |= QStyle.State_Open
-            super().drawPrimitive(element_, option_, painter, widget)
+            super(AccordionProxy, self).drawPrimitive(element_, option_, painter, widget)
         else:
-            super().drawPrimitive(element, option, painter, widget)
+            super(AccordionProxy, self).drawPrimitive(element, option, painter, widget)
 
 
 class AccordionGroup(QObject):
@@ -62,7 +63,7 @@ class AccordionGroup(QObject):
     """
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(AccordionGroup, self).__init__(parent)
         self._accordions = set()
         self._currentAccordion = None
         self._exclusive = True
@@ -161,7 +162,7 @@ class AccordionBox(QGroupBox):
     """
 
     def __init__(self, title=None, parent=None):
-        super().__init__(title, parent)
+        super(AccordionBox, self).__init__(title, parent)
         self.setCheckable(True)
         self.setFlat(True)
         self.setStyle(AccordionProxy())

--- a/Lib/defconQt/controls/baseCodeEditor.py
+++ b/Lib/defconQt/controls/baseCodeEditor.py
@@ -5,6 +5,7 @@ The *baseCodeEditor* submodule
 The *baseCodeEditor* submodule provides language-agnostic code editor parts,
 including a search widget, goto dialog and code highlighter.
 """
+from __future__ import division, absolute_import
 from defconQt.tools import platformSpecific
 from PyQt5.QtCore import pyqtSignal, QRegularExpression, QSize, Qt
 from PyQt5.QtGui import (
@@ -35,7 +36,7 @@ class GotoLineDialog(QDialog):
     """
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(GotoLineDialog, self).__init__(parent)
         self.setWindowModality(Qt.WindowModal)
         self.setWindowTitle(self.tr("Go to…"))
 
@@ -70,7 +71,7 @@ class GotoLineDialog(QDialog):
 class LineNumberArea(QWidget):
 
     def __init__(self, editor):
-        super().__init__(editor)
+        super(LineNumberArea, self).__init__(editor)
 
     def sizeHint(self):
         return QSize(self.parent().lineNumberAreaWidth(), 0)
@@ -97,7 +98,7 @@ class BaseCodeHighlighter(QSyntaxHighlighter):
     """
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(BaseCodeHighlighter, self).__init__(parent)
         self._blockHighlightingRules = []
         self._highlightingRules = []
         self._visited = set()
@@ -167,7 +168,7 @@ class BaseCodeHighlighter(QSyntaxHighlighter):
                 overlap = True
         self._visited.add((start, start+count))
         if not overlap:
-            super().setFormat(start, count, *args)
+            super(BaseCodeHighlighter, self).setFormat(start, count, *args)
 
 
 # -------------------
@@ -219,7 +220,7 @@ class BaseCodeEditor(QPlainTextEdit):
     indentChanged = pyqtSignal()
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(BaseCodeEditor, self).__init__(parent)
         self.setFont(platformSpecific.fixedFont())
         self._indent = "    "
         self._lineNumbersVisible = True
@@ -351,7 +352,7 @@ class BaseCodeEditor(QPlainTextEdit):
         self.setViewportMargins(self.lineNumberAreaWidth(), 0, 0, 0)
 
     def resizeEvent(self, event):
-        super().resizeEvent(event)
+        super(BaseCodeEditor, self).resizeEvent(event)
         cr = self.contentsRect()
         self.lineNumbers.setGeometry(cr.left(), cr.top(),
                                      self.lineNumberAreaWidth(), cr.height())
@@ -392,7 +393,7 @@ class BaseCodeEditor(QPlainTextEdit):
                                     QTextCursor.KeepAnchor)
                 if cursor.selectedText() == self.openBlockDelimiter:
                     indentLvl += 1
-            super().keyPressEvent(event)
+            super(BaseCodeEditor, self).keyPressEvent(event)
             newLineSpace = "".join(self._indent for _ in range(indentLvl))
             cursor = self.textCursor()
             cursor.insertText(newLineSpace)
@@ -405,19 +406,19 @@ class BaseCodeEditor(QPlainTextEdit):
             if cursor.selectedText() == self._indent:
                 cursor.removeSelectedText()
             else:
-                super().keyPressEvent(event)
+                super(BaseCodeEditor, self).keyPressEvent(event)
         elif key == Qt.Key_Tab:
             cursor = self.textCursor()
             cursor.insertText(self._indent)
         else:
-            super().keyPressEvent(event)
+            super(BaseCodeEditor, self).keyPressEvent(event)
 
     # --------------
     # Other builtins
     # --------------
 
     def setPlainText(self, text):
-        super().setPlainText(text)
+        super(BaseCodeEditor, self).setPlainText(text)
         if self._shouldGuessWhitespace and text is not None:
             indent = _guessMinWhitespace(text)
             self.setIndent(indent)
@@ -431,4 +432,4 @@ class BaseCodeEditor(QPlainTextEdit):
             font.setPointSize(newPointSize)
             self.setFont(font)
         else:
-            super().wheelEvent(event)
+            super(BaseCodeEditor, self).wheelEvent(event)

--- a/Lib/defconQt/controls/colorVignette.py
+++ b/Lib/defconQt/controls/colorVignette.py
@@ -2,6 +2,7 @@
 The *colorVignette* submodule
 -----------------------------
 """
+from __future__ import absolute_import
 from PyQt5.QtCore import pyqtSignal, QSize, Qt
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import (
@@ -26,7 +27,7 @@ class ColorVignette(QWidget):
     colorChanged = pyqtSignal()
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(ColorVignette, self).__init__(parent)
         self.setFocusPolicy(Qt.StrongFocus)
         self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
         self._color = None
@@ -125,13 +126,13 @@ class ColorVignette(QWidget):
             else:
                 self.pickColor()
         else:
-            super().keyPressEvent(event)
+            super(ColorVignette, self).keyPressEvent(event)
 
     def mousePressEvent(self, event):
         if self._mayClearColor and event.modifiers() & Qt.AltModifier:
             self.setColor(None)
         else:
-            super().mousePressEvent(event)
+            super(ColorVignette, self).mousePressEvent(event)
 
     def mouseDoubleClickEvent(self, event):
         self.pickColor()

--- a/Lib/defconQt/controls/featureCodeEditor.py
+++ b/Lib/defconQt/controls/featureCodeEditor.py
@@ -7,6 +7,7 @@ and a corresponding syntax highlighter.
 
 .. _`feature file`: http://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html
 """
+from __future__ import absolute_import
 from defconQt.controls.baseCodeEditor import (
     BaseCodeEditor, BaseCodeHighlighter)
 from PyQt5.QtCore import Qt
@@ -39,7 +40,7 @@ keywordPatterns = [
 class FeatureCodeHighlighter(BaseCodeHighlighter):
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(FeatureCodeHighlighter, self).__init__(parent)
 
         keywordFormat = QTextCharFormat()
         keywordFormat.setForeground(QColor(45, 95, 235))
@@ -71,7 +72,7 @@ class FeatureCodeEditor(BaseCodeEditor):
     openBlockDelimiter = '{'
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(FeatureCodeEditor, self).__init__(parent)
         self.highlighter = FeatureCodeHighlighter(self.document())
 
     def write(self, features):
@@ -134,7 +135,7 @@ class FeatureCodeEditor(BaseCodeEditor):
                 self.setTextCursor(cursor)
             cursor.endEditBlock()
         else:
-            super().keyPressEvent(event)
+            super(FeatureCodeEditor, self).keyPressEvent(event)
 
     def dragEnterEvent(self, event):
         if event.source() != self:
@@ -147,7 +148,7 @@ class FeatureCodeEditor(BaseCodeEditor):
                         event.acceptProposedAction()
                         break
                 return
-        super().dragEnterEvent(event)
+        super(FeatureCodeEditor, self).dragEnterEvent(event)
 
     def dropEvent(self, event):
         if event.source() != self:
@@ -170,4 +171,4 @@ class FeatureCodeEditor(BaseCodeEditor):
                 event = event.__class__(
                     event.posF(), event.possibleActions(), mimeData,
                     event.mouseButtons(), event.keyboardModifiers())
-        super().dropEvent(event)
+        super(FeatureCodeEditor, self).dropEvent(event)

--- a/Lib/defconQt/controls/glyphCellView.py
+++ b/Lib/defconQt/controls/glyphCellView.py
@@ -7,6 +7,7 @@ in cells with their names drawn inside headers.
 
 .. _Glyph: http://ts-defcon.readthedocs.org/en/ufo3/objects/glyph.html
 """
+from __future__ import division, absolute_import
 from defcon import Glyph
 from defconQt.tools.glyphsMimeData import GlyphsMimeData
 from PyQt5.QtCore import pyqtSignal, QSize, Qt
@@ -46,7 +47,7 @@ class GlyphCellWidget(QWidget):
     selectionChanged = pyqtSignal()
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(GlyphCellWidget, self).__init__(parent)
         self.setAttribute(Qt.WA_KeyCompression)
         self.setFocusPolicy(Qt.ClickFocus)
         self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
@@ -402,7 +403,7 @@ class GlyphCellWidget(QWidget):
             self.selectionChanged.emit()
             self.update()
         else:
-            super().mousePressEvent(event)
+            super(GlyphCellWidget, self).mousePressEvent(event)
 
     def mouseMoveEvent(self, event):
         if event.buttons() & Qt.LeftButton:
@@ -430,14 +431,14 @@ class GlyphCellWidget(QWidget):
             self.selectionChanged.emit()
             self.update()
         else:
-            super().mouseMoveEvent(event)
+            super(GlyphCellWidget, self).mouseMoveEvent(event)
 
     def mouseReleaseEvent(self, event):
         if event.button() == Qt.LeftButton:
             self._maybeDragPosition = None
             self._oldSelection = None
         else:
-            super().mouseReleaseEvent(event)
+            super(GlyphCellWidget, self).mouseReleaseEvent(event)
 
     def mouseDoubleClickEvent(self, event):
         if event.button() == Qt.LeftButton:
@@ -445,7 +446,7 @@ class GlyphCellWidget(QWidget):
             if index is not None:
                 self.glyphActivated.emit(self._glyphs[index])
         else:
-            super().mouseDoubleClickEvent(event)
+            super(GlyphCellWidget, self).mouseDoubleClickEvent(event)
 
     def _findIndexForEvent(self, event, allowAllViewport=False):
         cellHeight, cellWidth = self._cellHeight, self._cellWidth
@@ -486,7 +487,7 @@ class GlyphCellWidget(QWidget):
         elif modifiers in (Qt.NoModifier, Qt.ShiftModifier):
             self._glyphNameInputEvent(event)
         else:
-            super().keyPressEvent(event)
+            super(GlyphCellWidget, self).keyPressEvent(event)
 
     def _arrowKeyPressEvent(self, event):
         count = event.count()
@@ -609,7 +610,7 @@ class GlyphCellWidget(QWidget):
             # glyph reordering
             event.acceptProposedAction()
         else:
-            super().dragEnterEvent(event)
+            super(GlyphCellWidget, self).dragEnterEvent(event)
 
     def dragMoveEvent(self, event):
         pos = event.pos()
@@ -674,7 +675,7 @@ class GlyphCellView(QScrollArea):
     glyphCellWidgetClass = GlyphCellWidget
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(GlyphCellView, self).__init__(parent)
         self.setWidgetResizable(True)
 
         self._glyphCellWidget = self.glyphCellWidgetClass(self)

--- a/Lib/defconQt/controls/glyphLineView.py
+++ b/Lib/defconQt/controls/glyphLineView.py
@@ -7,6 +7,7 @@ The *glyphLineView* submodule provides widgets that render a list of Glyph_ or
 
 .. _Glyph: http://ts-defcon.readthedocs.org/en/ufo3/objects/glyph.html
 """
+from __future__ import division, absolute_import
 from defcon import Glyph
 from defconQt.tools import drawing
 from PyQt5.QtCore import pyqtSignal, QRectF, QSize, Qt
@@ -30,7 +31,7 @@ class GlyphLineWidget(QWidget):
     selectionModified = pyqtSignal(object)
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(GlyphLineWidget, self).__init__(parent)
         self.setAttribute(Qt.WA_OpaquePaintEvent)
         self.setFocusPolicy(Qt.ClickFocus)
         self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
@@ -444,7 +445,7 @@ class GlyphLineWidget(QWidget):
                 glyphRecord = self._glyphRecords[self._selected]
                 self.glyphActivated.emit(glyphRecord.glyph)
         else:
-            super().mouseDoubleClickEvent(event)
+            super(GlyphLineWidget, self).mouseDoubleClickEvent(event)
 
     def wheelEvent(self, event):
         if event.modifiers() & Qt.ControlModifier:
@@ -455,7 +456,7 @@ class GlyphLineWidget(QWidget):
             self.setPointSize(pointSize)
             self.pointSizeModified.emit(pointSize)
         else:
-            super().wheelEvent(event)
+            super(GlyphLineWidget, self).wheelEvent(event)
 
     # --------
     # Painting
@@ -613,7 +614,7 @@ class GlyphLineWidget(QWidget):
                 glyph = self._glyphRecords[index].glyph
                 self.glyphActivated.emit(glyph)
         else:
-            super().keyPressEvent(event)
+            super(GlyphLineWidget, self).keyPressEvent(event)
 
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
@@ -627,7 +628,7 @@ class GlyphLineWidget(QWidget):
             self.selectionModified.emit(self._selected)
             self.update()
         else:
-            super().mousePressEvent(event)
+            super(GlyphLineWidget, self).mousePressEvent(event)
 
     def paintEvent(self, event):
         painter = QPainter(self)
@@ -820,7 +821,7 @@ class GlyphLineView(QScrollArea):
     glyphLineWidgetClass = GlyphLineWidget
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(GlyphLineView, self).__init__(parent)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.setWidgetResizable(True)

--- a/Lib/defconQt/controls/glyphNameComboBox.py
+++ b/Lib/defconQt/controls/glyphNameComboBox.py
@@ -8,6 +8,7 @@ autocompletion from a Font_’s glyph names.
 .. _Font: http://ts-defcon.readthedocs.org/en/ufo3/objects/font.html
 .. _QComboBox: http://doc.qt.io/qt-5/qcombobox.html
 """
+from __future__ import absolute_import
 from defconQt.tools.textSplitter import splitText
 from PyQt5.QtCore import QStringListModel
 from PyQt5.QtWidgets import QCompleter, QComboBox
@@ -18,7 +19,7 @@ __all__ = ["GlyphNameComboBox"]
 class GlyphNameCompleter(QCompleter):
 
     def __init__(self, font, parent=None):
-        super().__init__(parent)
+        super(GlyphNameCompleter, self).__init__(parent)
         self._font = font
         self.setCompletionMode(QCompleter.InlineCompletion)
 
@@ -46,7 +47,7 @@ class GlyphNameComboBox(QComboBox):
     splitTextFunction = splitText
 
     def __init__(self, font, parent=None):
-        super().__init__(parent)
+        super(GlyphNameComboBox, self).__init__(parent)
         self.setEditable(True)
         completer = GlyphNameCompleter(font)
         self.setCompleter(completer)

--- a/Lib/defconQt/controls/glyphSequenceEdit.py
+++ b/Lib/defconQt/controls/glyphSequenceEdit.py
@@ -9,6 +9,7 @@ constructor.
 .. _Glyph: http://ts-defcon.readthedocs.org/en/ufo3/objects/glyph.html
 .. _QLineEdit: http://doc.qt.io/qt-5/qlineedit.html
 """
+from __future__ import absolute_import
 from defconQt.tools.textSplitter import splitText
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QComboBox, QCompleter, QLineEdit
@@ -27,7 +28,7 @@ class GlyphSequenceComboBox(QComboBox):
     splitTextFunction = staticmethod(splitText)
 
     def __init__(self, font, parent=None):
-        super().__init__(parent)
+        super(GlyphSequenceComboBox, self).__init__(parent)
         # setEditable(True) must be called before self.completer()
         # otherwise it will return None
         self.setEditable(True)
@@ -49,7 +50,7 @@ class GlyphSequenceEdit(QLineEdit):
     splitTextFunction = staticmethod(splitText)
 
     def __init__(self, font, parent=None):
-        super().__init__(parent)
+        super(GlyphSequenceEdit, self).__init__(parent)
         self._font = font
 
     glyphs = _glyphs

--- a/Lib/defconQt/controls/glyphView.py
+++ b/Lib/defconQt/controls/glyphView.py
@@ -7,6 +7,7 @@ various display parameters.
 
 .. _Glyph: http://ts-defcon.readthedocs.org/en/ufo3/objects/glyph.html
 """
+from __future__ import division, absolute_import
 from defconQt.tools import drawing, platformSpecific
 from PyQt5.QtCore import pyqtSignal, QPoint, QPointF, QSize, Qt
 from PyQt5.QtGui import QCursor, QPainter
@@ -24,7 +25,7 @@ class GlyphWidget(QWidget):
     pointSizeChanged = pyqtSignal(int)
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(GlyphWidget, self).__init__(parent)
         self.setFocusPolicy(Qt.ClickFocus)
         self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
         self._glyph = None
@@ -533,7 +534,7 @@ class GlyphWidget(QWidget):
         painter.restore()
 
     def resizeEvent(self, event):
-        super().resizeEvent(event)
+        super(GlyphWidget, self).resizeEvent(event)
         self._calculateDrawingRect()
 
     def sizeHint(self):
@@ -555,7 +556,7 @@ class GlyphWidget(QWidget):
         return QSize(width, height)
 
     def showEvent(self, event):
-        super().showEvent(event)
+        super(GlyphWidget, self).showEvent(event)
         self._calculateDrawingRect()
         self.fitScaleBBox()
 
@@ -564,14 +565,14 @@ class GlyphWidget(QWidget):
             step = event.angleDelta().y() / 120.0
             self.zoom(step, event.pos())
         else:
-            super().wheelEvent(event)
+            super(GlyphWidget, self).wheelEvent(event)
 
 
 class GlyphView(QScrollArea):
     glyphWidgetClass = GlyphWidget
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(GlyphView, self).__init__(parent)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
         self.setWidgetResizable(True)

--- a/Lib/defconQt/controls/listView.py
+++ b/Lib/defconQt/controls/listView.py
@@ -7,6 +7,7 @@ lists_.
 
 .. _lists: https://docs.python.org/3/tutorial/introduction.html#lists
 """
+from __future__ import absolute_import
 from defcon import Font, Glyph
 from PyQt5.QtCore import pyqtSignal, QAbstractTableModel, QItemSelectionModel, QModelIndex, Qt
 from PyQt5.QtWidgets import QAbstractItemView, QStyledItemDelegate, QTreeView
@@ -18,7 +19,7 @@ class AbstractListModel(QAbstractTableModel):
     valueChanged = pyqtSignal(QModelIndex, object, object)
 
     def __init__(self, lst, parent=None):
-        super().__init__(parent)
+        super(AbstractListModel, self).__init__(parent)
         self._headerLabels = []
 
         self.setList(lst)
@@ -82,7 +83,7 @@ class AbstractListModel(QAbstractTableModel):
             self.valueChanged.emit(index, oldValue, value)
             self.dataChanged.emit(index, index, [role])
             return True
-        return super().setData(index, value, role)
+        return super(AbstractListModel, self).setData(index, value, role)
 
     def columnCount(self, parent=QModelIndex()):
         # flat table
@@ -117,7 +118,7 @@ class AbstractListModel(QAbstractTableModel):
             return False
         # force column 0, we want to drag column onto the start of the
         # drop spot, otherwise it will be split between two new columns
-        return super().dropMimeData(data, action, row, 0, parent)
+        return super(AbstractListModel, self).dropMimeData(data, action, row, 0, parent)
 
     def flags(self, index):
         flags = Qt.ItemIsEnabled | Qt.ItemIsSelectable \
@@ -136,13 +137,13 @@ class AbstractListModel(QAbstractTableModel):
                 return None
             else:
                 return self._headerLabels[section]
-        return super().headerData(section, orientation, role)
+        return super(AbstractListModel, self).headerData(section, orientation, role)
 
 
 class FlatListModel(AbstractListModel):
 
     def __init__(self, lst, columnCount=1, parent=None):
-        super().__init__(lst, parent)
+        super(FlatListModel, self).__init__(lst, parent)
         self._columns = columnCount
 
     def _data(self, row, column):
@@ -222,7 +223,7 @@ class ListItemDelegate(QStyledItemDelegate):
         elif isinstance(value, Glyph):
             return value.name
         else:
-            return super().displayText(value, locale)
+            return super(ListItemDelegate, self).displayText(value, locale)
 
 
 class ListView(QTreeView):
@@ -252,7 +253,7 @@ class ListView(QTreeView):
     oneTwoListModelClass = OneTwoListModel
 
     def __init__(self, parent=None):
-        super().__init__(parent)
+        super(ListView, self).__init__(parent)
         self.setItemDelegate(ListItemDelegate())
         self.setRootIsDecorated(False)
         self.header().setVisible(False)
@@ -263,7 +264,7 @@ class ListView(QTreeView):
         self.selectionChanged_.emit()
 
     def currentChanged(self, current, previous):
-        super().currentChanged(current, previous)
+        super(ListView, self).currentChanged(current, previous)
         model = self.model()
         self.currentItemChanged.emit(model.data(current))
 
@@ -292,12 +293,12 @@ class ListView(QTreeView):
                     self.editorDestroyed(widget)
                     # store it
                     cachedWidgets.append((col, widget))
-            super().dropEvent(event)
+            super(ListView, self).dropEvent(event)
             for col, widget in cachedWidgets:
                 index = model.index(dropRow, col)
                 self.setIndexWidget(index, widget)
         else:
-            super().dropEvent(event)
+            super(ListView, self).dropEvent(event)
 
     def currentRow(self):
         index = self.currentIndex()
@@ -322,7 +323,7 @@ class ListView(QTreeView):
         if model is None:
             return
         index = model.index(row, column)
-        super().setCurrentIndex(index)
+        super(ListView, self).setCurrentIndex(index)
 
     def setEditable(self, value):
         """

--- a/Lib/defconQt/representationFactories/__init__.py
+++ b/Lib/defconQt/representationFactories/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from defcon import Glyph, Image, registerRepresentationFactory
 from defconQt.representationFactories.glyphCellFactory import (
     GlyphCellFactory)

--- a/Lib/defconQt/representationFactories/glyphCellFactory.py
+++ b/Lib/defconQt/representationFactories/glyphCellFactory.py
@@ -1,3 +1,4 @@
+from __future__ import division, absolute_import
 from defconQt.tools import drawing, platformSpecific
 from defconQt.tools.drawing import colorToQColor
 from PyQt5.QtCore import Qt

--- a/Lib/defconQt/representationFactories/glyphViewFactory.py
+++ b/Lib/defconQt/representationFactories/glyphViewFactory.py
@@ -8,6 +8,7 @@ handles, components etc.).
 
 .. _Glyph: http://ts-defcon.readthedocs.org/en/ufo3/objects/glyph.html
 """
+from __future__ import division, absolute_import
 from fontTools.pens.basePen import BasePen
 from fontTools.pens.transformPen import TransformPen
 from fontTools.pens.qtPen import QtPen
@@ -49,7 +50,7 @@ def OnlyComponentsQPainterPathFactory(glyph):
 class OnlyComponentsQtPen(BasePen):
 
     def __init__(self, glyphSet):
-        super().__init__(glyphSet)
+        super(OnlyComponentsQtPen, self).__init__(glyphSet)
         self.pen = QtPen(glyphSet)
         self.path = self.pen.path
 

--- a/Lib/defconQt/representationFactories/qPainterPathFactory.py
+++ b/Lib/defconQt/representationFactories/qPainterPathFactory.py
@@ -15,6 +15,7 @@ You can then draw such paths on screen with the QPainter_ method
 .. _QPainter: http://doc.qt.io/qt-5/qpainter.html
 .. _QPainterPath: http://doc.qt.io/qt-5/qpainterpath.html
 """
+from __future__ import absolute_import
 from fontTools.pens.qtPen import QtPen
 from PyQt5.QtCore import Qt
 

--- a/Lib/defconQt/tools/drawing.py
+++ b/Lib/defconQt/tools/drawing.py
@@ -12,6 +12,7 @@ Notes:
 - The *rect* argument is the rect that the glyph is being drawn in
 
 """
+from __future__ import division, absolute_import
 from defcon import Color
 from PyQt5.QtCore import QPointF, QRectF, Qt
 from PyQt5.QtGui import (

--- a/Lib/defconQt/tools/glyphsMimeData.py
+++ b/Lib/defconQt/tools/glyphsMimeData.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 from PyQt5.QtCore import QMimeData
 
 
 class GlyphsMimeData(QMimeData):
     def __init__(self):
-        super().__init__()
+        super(GlyphsMimeData, self).__init__()
         # we don't need to serialize until we want to do cross-app dnd
         self._glyphs = []
 
@@ -18,16 +19,16 @@ class GlyphsMimeData(QMimeData):
     # ----------
 
     def formats(self):
-        formats = super().formats()
+        formats = super(GlyphsMimeData, self).formats()
         formats.append("text/plain")
         return formats
 
     def hasFormat(self, format_):
         if format_ == "text/plain":
             return True
-        return super().hasFormat(format_)
+        return super(GlyphsMimeData, self).hasFormat(format_)
 
     def retrieveData(self, mimeType, type_):
         if mimeType == "text/plain":
             return " ".join(glyph.name for glyph in self._glyphs)
-        return super().retrieveData(mimeType, type_)
+        return super(GlyphsMimeData, self).retrieveData(mimeType, type_)

--- a/Lib/defconQt/tools/platformSpecific.py
+++ b/Lib/defconQt/tools/platformSpecific.py
@@ -13,6 +13,7 @@ such code obvious and self-contained.
 Fear not, these occurrences are rather anecdotic as you may tell from the size
 of this file.
 """
+from __future__ import absolute_import
 from PyQt5.QtGui import QFont, QFontDatabase
 import sys
 

--- a/Lib/defconQt/windows/baseWindows.py
+++ b/Lib/defconQt/windows/baseWindows.py
@@ -29,6 +29,7 @@ its documentation for more details.
 .. _QMainWindow: http://doc.qt.io/qt-5/qmainwindow.html
 .. _`Garbage Collector`: https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)
 """
+from __future__ import absolute_import
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication, QMainWindow, QWidget
 
@@ -50,12 +51,12 @@ class BaseMainWindow(QMainWindow):
     """
 
     def __init__(self, parent=None, flags=Qt.Window):
-        super().__init__(parent, flags)
+        super(BaseMainWindow, self).__init__(parent, flags)
         self.setAttribute(Qt.WA_DeleteOnClose)
         _bootstrapGCCache(self)
 
     def closeEvent(self, event):
-        super().closeEvent(event)
+        super(BaseMainWindow, self).closeEvent(event)
         if event.isAccepted():
             app = QApplication.instance()
             app._windowCache.remove(self)
@@ -73,12 +74,12 @@ class BaseWindow(QWidget):
     """
 
     def __init__(self, parent=None, flags=Qt.Window):
-        super().__init__(parent, flags)
+        super(BaseWindow, self).__init__(parent, flags)
         self.setAttribute(Qt.WA_DeleteOnClose)
         _bootstrapGCCache(self)
 
     def closeEvent(self, event):
-        super().closeEvent(event)
+        super(BaseWindow, self).closeEvent(event)
         if event.isAccepted():
             app = QApplication.instance()
             app._windowCache.remove(self)


### PR DESCRIPTION
I'd like to make defconQt work with python 2 as well as python 3. Most other font editors only work with python 2.7, and it would be nice if defconQt module could work there as well.

Here I used the [3to2](https://pypi.python.org/pypi/3to2) script to do a first pass.
TruFont seems to work fine after these changes.

