### PR TITLE
Improve drawing glyph cell on Hi-DPI systems

### DIFF
--- a/Lib/defconQt/controls/glyphCellView.py
+++ b/Lib/defconQt/controls/glyphCellView.py
@@ -86,6 +86,7 @@ class GlyphCellWidget(QWidget):
         args = self._cellRepresentationArguments
         args["width"] = self._cellWidth
         args["height"] = self._cellHeight
+        args["pixelRatio"] = self.devicePixelRatio()
         return glyph.getRepresentation(name, **args)
 
     def preloadGlyphCellImages(self):
@@ -274,8 +275,7 @@ class GlyphCellWidget(QWidget):
 
             if visibleRect.intersects(visibleRect.__class__(*rect)):
                 pixmap = self._getCurrentRepresentation(glyph)
-                painter.drawPixmap(
-                    left, t, pixmap, 0, 0, cellWidth, cellHeight)
+                painter.drawPixmap(left, t, pixmap)
 
                 if index in self._selection:
                     # TODO: draw focusRect on lastSelectedCell

--- a/Lib/defconQt/representationFactories/glyphCellFactory.py
+++ b/Lib/defconQt/representationFactories/glyphCellFactory.py
@@ -23,12 +23,12 @@ headerFont = platformSpecific.otherUIFont()
 # TODO: show a symbol for content present on other layers
 
 
-def GlyphCellFactory(glyph, width, height, drawLayers=False, drawMarkColor=True, drawHeader=None, drawMetrics=None):
+def GlyphCellFactory(glyph, width, height, drawLayers=False, drawMarkColor=True, drawHeader=None, drawMetrics=None, pixelRatio=1.0):
     if drawHeader is None:
         drawHeader = height >= GlyphCellMinHeightForHeader
     if drawMetrics is None:
         drawMetrics = height >= GlyphCellMinHeightForMetrics
-    obj = GlyphCellFactoryDrawingController(glyph=glyph, font=glyph.font, width=width, height=height, drawLayers=False, drawMarkColor=drawMarkColor, drawHeader=drawHeader, drawMetrics=drawMetrics)
+    obj = GlyphCellFactoryDrawingController(glyph=glyph, font=glyph.font, width=width, height=height, drawLayers=False, drawMarkColor=drawMarkColor, drawHeader=drawHeader, drawMetrics=drawMetrics, pixelRatio=pixelRatio)
     return obj.getPixmap()
 
 
@@ -56,10 +56,11 @@ class GlyphCellFactoryDrawingController(object):
     the appearance of cells.
     """
 
-    def __init__(self, glyph, font, width, height,
+    def __init__(self, glyph, font, width, height, pixelRatio=1.0,
                  drawLayers=False, drawMarkColor=True, drawHeader=True, drawMetrics=False):
         self.glyph = glyph
         self.font = font
+        self.pixelRatio = pixelRatio
         self.width = width
         self.height = height
         self.bufferPercent = .15
@@ -79,7 +80,8 @@ class GlyphCellFactoryDrawingController(object):
         self.yOffset = abs(font.info.descender * self.scale) + self.buffer
 
     def getPixmap(self):
-        pixmap = QPixmap(self.width, self.height)
+        pixmap = QPixmap(self.width * self.pixelRatio, self.height * self.pixelRatio)
+        pixmap.setDevicePixelRatio(self.pixelRatio)
         pixmap.fill(Qt.transparent)
         painter = QPainter(pixmap)
         painter.setRenderHint(QPainter.Antialiasing)


### PR DESCRIPTION
Passing a pixmap around does not allow for pixel scaling causing the
font window glyph cell to look fuzzy.

Before:
![2016-04-30 06-07-03](https://cloud.githubusercontent.com/assets/93914/14933803/1949458c-0ea3-11e6-8b25-500a01d98f3d.png)

After:
![2016-04-30 06-08-08](https://cloud.githubusercontent.com/assets/93914/14933806/27f1e918-0ea3-11e6-8871-88e93fc29eb1.png)

