### PR TITLE
Make sure newSelection is defined

### DIFF
--- a/Lib/defconQt/controls/glyphCellView.py
+++ b/Lib/defconQt/controls/glyphCellView.py
@@ -577,6 +577,7 @@ class GlyphCellWidget(QWidget):
                     lastResortIndex = index
                     continue
 
+        newSelection = None
         if matchIndex is not None:
             newSelection = matchIndex
         elif lastResortIndex is not None:


### PR DESCRIPTION
If both matchIndex and lastResortIndex are None then newSelection will
be undefined. No idea why and no clear way to reproduce it other than
randomly pressing on key while shift is pressed.